### PR TITLE
Allow element_proc to be passed via options or html_options

### DIFF
--- a/app/components/concerns/view_component/form/element_proc.rb
+++ b/app/components/concerns/view_component/form/element_proc.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module ViewComponent
+  module Form
+    module ElementProc
+      attr_reader :element_proc
+
+      def initialize(*args, **kwargs)
+        super
+        set_element_proc!
+      end
+
+      protected
+
+      def set_element_proc!
+        options_element_proc = options.delete(:element_proc)
+        html_options_element_proc = html_options.delete(:element_proc)
+
+        if options_element_proc && html_options_element_proc
+          raise ArgumentError, "#{self.class.name} received :element_proc twice, expected only once"
+        end
+
+        @element_proc = options_element_proc || html_options_element_proc
+      end
+    end
+  end
+end

--- a/app/components/view_component/form/collection_check_boxes_component.rb
+++ b/app/components/view_component/form/collection_check_boxes_component.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module Form
     class CollectionCheckBoxesComponent < FieldComponent
-      attr_reader :collection, :value_method, :text_method, :html_options
+      attr_reader :collection, :value_method, :text_method, :html_options, :element_proc
 
       def initialize( # rubocop:disable Metrics/ParameterLists
         form,
@@ -22,12 +22,11 @@ module ViewComponent
 
         super(form, object_name, method_name, options)
 
+        set_element_proc!
         set_html_options!
       end
 
       def call # rubocop:disable Metrics/MethodLength
-        element_proc = options.delete(:element_proc)
-
         ActionView::Helpers::Tags::CollectionCheckBoxes.new(
           object_name,
           method_name,
@@ -42,6 +41,17 @@ module ViewComponent
       end
 
       protected
+
+      def set_element_proc!
+        options_element_proc = options.delete(:element_proc)
+        html_options_element_proc = html_options.delete(:element_proc)
+
+        if options_element_proc && html_options_element_proc
+          raise ArgumentError, "#{self.class.name} received :element_proc twice, expected only once"
+        end
+
+        @element_proc = options_element_proc || html_options_element_proc
+      end
 
       def set_html_options!
         @html_options[:class] = class_names(html_options[:class], html_class)

--- a/app/components/view_component/form/collection_check_boxes_component.rb
+++ b/app/components/view_component/form/collection_check_boxes_component.rb
@@ -3,7 +3,9 @@
 module ViewComponent
   module Form
     class CollectionCheckBoxesComponent < FieldComponent
-      attr_reader :collection, :value_method, :text_method, :html_options, :element_proc
+      include ElementProc
+
+      attr_reader :collection, :value_method, :text_method, :html_options
 
       def initialize( # rubocop:disable Metrics/ParameterLists
         form,
@@ -22,7 +24,6 @@ module ViewComponent
 
         super(form, object_name, method_name, options)
 
-        set_element_proc!
         set_html_options!
       end
 
@@ -41,17 +42,6 @@ module ViewComponent
       end
 
       protected
-
-      def set_element_proc!
-        options_element_proc = options.delete(:element_proc)
-        html_options_element_proc = html_options.delete(:element_proc)
-
-        if options_element_proc && html_options_element_proc
-          raise ArgumentError, "#{self.class.name} received :element_proc twice, expected only once"
-        end
-
-        @element_proc = options_element_proc || html_options_element_proc
-      end
 
       def set_html_options!
         @html_options[:class] = class_names(html_options[:class], html_class)

--- a/app/components/view_component/form/collection_radio_buttons_component.rb
+++ b/app/components/view_component/form/collection_radio_buttons_component.rb
@@ -3,7 +3,7 @@
 module ViewComponent
   module Form
     class CollectionRadioButtonsComponent < FieldComponent
-      attr_reader :collection, :value_method, :text_method, :html_options
+      attr_reader :collection, :value_method, :text_method, :html_options, :element_proc
 
       def initialize( # rubocop:disable Metrics/ParameterLists
         form,
@@ -22,12 +22,11 @@ module ViewComponent
 
         super(form, object_name, method_name, options)
 
+        set_element_proc!
         set_html_options!
       end
 
       def call # rubocop:disable Metrics/MethodLength
-        element_proc = options.delete(:element_proc)
-
         ActionView::Helpers::Tags::CollectionRadioButtons.new(
           object_name,
           method_name,
@@ -42,6 +41,17 @@ module ViewComponent
       end
 
       protected
+
+      def set_element_proc!
+        options_element_proc = options.delete(:element_proc)
+        html_options_element_proc = html_options.delete(:element_proc)
+
+        if options_element_proc && html_options_element_proc
+          raise ArgumentError, "#{self.class.name} received :element_proc twice, expected only once"
+        end
+
+        @element_proc = options_element_proc || html_options_element_proc
+      end
 
       def set_html_options!
         @html_options[:class] = class_names(html_options[:class], html_class)

--- a/app/components/view_component/form/collection_radio_buttons_component.rb
+++ b/app/components/view_component/form/collection_radio_buttons_component.rb
@@ -3,7 +3,9 @@
 module ViewComponent
   module Form
     class CollectionRadioButtonsComponent < FieldComponent
-      attr_reader :collection, :value_method, :text_method, :html_options, :element_proc
+      include ElementProc
+
+      attr_reader :collection, :value_method, :text_method, :html_options
 
       def initialize( # rubocop:disable Metrics/ParameterLists
         form,
@@ -22,7 +24,6 @@ module ViewComponent
 
         super(form, object_name, method_name, options)
 
-        set_element_proc!
         set_html_options!
       end
 
@@ -41,17 +42,6 @@ module ViewComponent
       end
 
       protected
-
-      def set_element_proc!
-        options_element_proc = options.delete(:element_proc)
-        html_options_element_proc = html_options.delete(:element_proc)
-
-        if options_element_proc && html_options_element_proc
-          raise ArgumentError, "#{self.class.name} received :element_proc twice, expected only once"
-        end
-
-        @element_proc = options_element_proc || html_options_element_proc
-      end
 
       def set_html_options!
         @html_options[:class] = class_names(html_options[:class], html_class)

--- a/lib/view_component/form/engine.rb
+++ b/lib/view_component/form/engine.rb
@@ -6,6 +6,7 @@ module ViewComponent
     class Engine < ::Rails::Engine
       config.autoload_once_paths = %W[
         #{root}/app/components
+        #{root}/app/components/concerns
         #{root}/app/lib
       ]
     end

--- a/spec/view_component/form/collection_radio_buttons_component_spec.rb
+++ b/spec/view_component/form/collection_radio_buttons_component_spec.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe ViewComponent::Form::CollectionRadioButtonsComponent, type: :component do
-  let(:object)       { OpenStruct.new }
-  let(:form)         { form_with(object) }
-  let(:collection)   { [OpenStruct.new(name: "Belgium", code: "BE"), OpenStruct.new(name: "France", code: "FR")] }
-  let(:options)      { {} }
-  let(:html_options) { {} }
-
-  let(:component) do
+  subject(:component) do
     render_inline(described_class.new(
                     form,
                     object_name,
@@ -19,7 +13,13 @@ RSpec.describe ViewComponent::Form::CollectionRadioButtonsComponent, type: :comp
                     html_options
                   ))
   end
+
+  let(:object) { OpenStruct.new }
   let(:component_html_attributes) { component.css("input").last.attributes }
+  let(:form)         { form_with(object) }
+  let(:collection)   { [OpenStruct.new(name: "Belgium", code: "BE"), OpenStruct.new(name: "France", code: "FR")] }
+  let(:options)      { {} }
+  let(:html_options) { {} }
 
   context "with simple args" do
     it do
@@ -54,23 +54,43 @@ RSpec.describe ViewComponent::Form::CollectionRadioButtonsComponent, type: :comp
   end
 
   context "with an element proc" do
-    let(:options) do
-      {
-        element_proc: proc do |b|
-          "<div class='wrapper'>
-            #{b.radio_button}
-            #{b.label}
-          </div>".html_safe
-        end
-      }
+    let(:element_proc) do
+      proc do |b|
+        "<div class='wrapper'>
+          #{b.radio_button}
+          #{b.label}
+        </div>".html_safe
+      end
     end
 
-    it do
-      expect(component.to_html)
-        .to have_tag(".wrapper input", with: {
-                       type: "radio", value: "BE",
-                       id: "user_nationality_be", name: "user[nationality]"
-                     })
+    %i[options html_options].each do |option_arg|
+      context "when passed via #{option_arg}" do
+        before do
+          public_send(option_arg)[:element_proc] = element_proc
+        end
+
+        it do
+          expect(component.to_html)
+            .to have_tag(".wrapper input", with: {
+                           type: "radio", value: "BE",
+                           id: "user_nationality_be", name: "user[nationality]"
+                         })
+        end
+      end
+    end
+
+    context "when passed via both options and html_options" do
+      before do
+        options[:element_proc] = element_proc
+        html_options[:element_proc] = element_proc
+      end
+
+      it do
+        expect { component }
+          .to raise_error(ArgumentError,
+                          "ViewComponent::Form::CollectionRadioButtonsComponent " \
+                          "received :element_proc twice, expected only once")
+      end
     end
   end
 


### PR DESCRIPTION
@wooly @Spone Here's a first draft of the proposed change.

I moved the code to extract the `element_proc` into a new method and it now raises if it receives two `element_proc` options. This could be extracted somewhere, but I'm not sure if there's already a good place for it. I thought about introducing a `CollectionFieldComponent`, but it feels too big of a change.

Also I'm not sure why `set_html_options!` is a bang method, but I followed the naming convention? and named the new method accordingly.

Let me know what you think, what needs to be changed, ...
and enjoy your holidays!